### PR TITLE
Differentiate between buttons and text info

### DIFF
--- a/checkout.py
+++ b/checkout.py
@@ -1,6 +1,6 @@
 import cv2
-import csv
 from cvzone.HandTrackingModule import HandDetector
+import cvzone
 
 CAM_HEIGHT = 720
 CAM_WIDTH = 1280
@@ -19,18 +19,20 @@ class Page():
     def update(self,cursor,pageNum):
         for key in self.buttons:
             x1,y1,x2,y2 = self.buttons[key]
-            if x1<cursor[0]<x2 and y1<cursor[1]<y2:
-                cv2.rectangle(img,(x1,y1),(x2,y2),(0,255,0),cv2.FILLED)
-                if key == "pay":
-                    return 1
-                elif key == "help":
-                    return 2
-                elif key == "remove":
-                    return 3
-                elif key == "loyalty":
-                    return 4
-                else:
-                    return 0
+            #only consider buttons for updating pages
+            if x2 != 'not a button':
+                if x1<cursor[0]<x2 and y1<cursor[1]<y2:
+                    cv2.rectangle(img,(x1,y1),(x2,y2),(0,255,0),cv2.FILLED)
+                    if key == "pay":
+                        return 1
+                    elif key == "help":
+                        return 2
+                    elif key == "remove":
+                        return 3
+                    elif key == "loyalty":
+                        return 4
+                    else:
+                        return 0
         else:
             return pageNum
 
@@ -50,15 +52,15 @@ pagesDict = {
         "cancel":(130,500,430,650)
     },
     "help":{
-        "Help is on the way":(100,50,500,470),
+        "Help is on the way":(100,50, 'not a button', False),
         "cancel":(130,500,430,650)
     },
     "remove":{
-        "Please scan the item you would like to remove":(100,50,500,470),
+        "Please scan the item you would like to remove":(100,50, 'not a button', False),
         "cancel":(130,500,430,650)
     },
     "loyalty":{
-        "Please scan your loyalty card":(100,50,500,470),
+        "Please scan your loyalty card":(100, 50, 'not a button', False),
         "cancel":(130,500,430,650)
     }   
 }
@@ -75,9 +77,14 @@ while True:
     page = pages[pageNum]
 
     for key in page.buttons:
-        x1,y1,x2,y2 = page.buttons[key]
-        img = cv2.rectangle(img, (x1, y1), (x2, y2), (255, 0, 0), -1)
-        img = cv2.putText(img, key, ((x1+x2)//2-50, (y1+y2)//2), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+        x1, y1, x2, y2 = page.buttons[key]
+        #behaviour for buttons (in blue)
+        if x2 != 'not a button':
+            img = cv2.rectangle(img, (x1, y1), (x2, y2), (255, 0, 0), -1)
+            img = cv2.putText(img, key, ((x1+x2)//2-50, (y1+y2)//2), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+        else:
+            #behaviour for text boxes with information (in magenta)
+            cvzone.putTextRect(img, key, [x1, y1], 3, 4)
 
     
     if hands:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53841219/133892923-7c0e8410-cefa-4e0e-849e-ac2211a1a8e1.png)
Distinguish visually differences between buttons that users can "press" (in blue) and text information on the screen (in magenta)

- Now when users try to press on magenta text boxes, nothing happens as it's no longer a button